### PR TITLE
Lowercase credentials vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
 install:
   - pip install molecule
-  - pip install docker-py
+  - pip install docker
 script:
   # Replace with `molecule --debug test` for debugging.
   - molecule test

--- a/README.md
+++ b/README.md
@@ -14,8 +14,20 @@ No special requirements.
 
 ## Role Variables
 
-- `aws_users` (default `[]`): a list of aws users to configure once aws cli is
-  installed.
+| Variable Name | Default | Use |
+|---------------|---------|-----|
+| `aws_users` | `[]` | A list of aws users to configure once `aws-cli` is installed. |
+| `aws_users` > `name` | `-` | Each item in `aws_users` should include the `name` of a user to configure `aws-cli` for. |
+| `aws_users` > `group` | `-` | Each item in `aws_users` should include the `group` of the user to configure `aws-cli` for. |
+| `aws_users` > `region` | `-` | Each item in `aws_users` should include the aws region to add to the `config` file for the user. |
+| `aws_users` > `output` | `-` | Each item in `aws_users` should include the `output` format for the `config` file for the user. |
+| `aws_users` > `home` | `-` | Eacy item in `aws_users` should include the path to the `home` directory containing the users' home directory. |
+| `aws_config` | `config.j2` | The template file used to create the `config` file in the `.aws` directory. |
+| `aws_credentials` | `credentials.j2` | The template file used to create the `credentials` file in the `.aws` directory. |
+| `aws_access_key_id` | `""` | The aws access key id used to access an aws account. |
+| `aws_secret_access_key` | `""` | The secret access key use to access an aws account. |
+
+### Example `aws_users` configuration
 
   ```yaml
   # Example `aws_users` configuration.
@@ -26,12 +38,6 @@ No special requirements.
       output: json
       home: /var/lib
   ```
-
-- `aws_cli_config` (default `config.js`): the filename or path to the template file used to
-  create `~/.aws/config`.
-
-- `aws_cli_credentials` (default `credentials.js`): the filename or path to the template file
-  used to create `~/.aws/credentials`.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@
 
 aws_config: "config.j2"
 aws_credentials: "credentials.j2"
+aws_access_key_id: ""
+aws_secret_access_key: ""

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -11,5 +11,5 @@
         region: "us-east-1"
         output: "json"
         home: "/var/lib"
-    AWS_ACCESS_KEY_ID: "molecule-aws-access-key-id"
-    AWS_SECRET_ACCESS_KEY: "molecule-aws-secret-access-key"
+    aws_access_key_id: "molecule-aws-access-key-id"
+    aws_secret_access_key: "molecule-aws-secret-access-key"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,5 @@
     group: "{{ item.group }}"
     force: "yes"
   with_items: "{{ aws_users | default([]) }}"
+  no_log: true
   become: true

--- a/templates/credentials.j2
+++ b/templates/credentials.j2
@@ -1,3 +1,3 @@
 [default]
-aws_access_key_id={{ AWS_ACCESS_KEY_ID }}
-aws_secret_access_key={{ AWS_SECRET_ACCESS_KEY }}
+aws_access_key_id={{ aws_access_key_id }}
+aws_secret_access_key={{ aws_secret_access_key }}


### PR DESCRIPTION
We're going to begin using this in another location, so I lowercased the variable names. This led to me finding a couple of other issues to address:

- The variables were only about half documented,
- We were permitting aws access key id and secret key to show up in the console when playbooks run,
- Not all of the 'settable' variables were shown in `defaults/main.yml`.